### PR TITLE
fixed ffmpeg for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,11 @@ add_custom_command(TARGET EasyWhisperUI POST_BUILD
 )
 endif()
 if (APPLE)
-add_custom_command(TARGET EasyWhisperUI POST_BUILD
+add_custom_target(
+    buildOSXApp ALL
+    DEPENDS EasyWhisperUI
+) 
+add_custom_command(TARGET buildOSXApp POST_BUILD
     # Make output folder
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_SOURCE_DIR}/build/Final"
 

--- a/build.sh
+++ b/build.sh
@@ -2,16 +2,22 @@
 
 build_dir=$(cd "$(dirname "$0")"; pwd -P)/build/Final
 
-# Download whisper.cpp
-cd $build_dir
-git clone https://github.com/ggml-org/whisper.cpp.git
 
-# Change to the whisper.cpp directory
-cd "$build_dir/whisper.cpp"
+if [ -f $build_dir/whisper.cpp/build/bin/whisper-cli ]; then
+    # Do not rebuild whisper-cli
+    echo "using existing whisper.cpp"
+else
+    # Download whisper.cpp
+    cd $build_dir
+    git clone https://github.com/ggml-org/whisper.cpp.git
 
-# Run CMake and build
-cmake -B build -DGGML_METAL=ON -DWHISPER_SDL2=ON -DBUILD_SHARED_LIBS=OFF -DGGML_METAL_EMBED_LIBRARY=ON
-cmake --build build --clean-first --config Release --parallel 8
+    # Change to the whisper.cpp directory
+    cd "$build_dir/whisper.cpp"
+
+    # Run CMake and build
+    cmake -B build -DGGML_METAL=ON -DWHISPER_SDL2=ON -DBUILD_SHARED_LIBS=OFF -DGGML_METAL_EMBED_LIBRARY=ON
+    cmake --build build --clean-first --config Release --parallel 8
+fi
 
 # Copy the whisper-cli binary into the bundle
 cp "$build_dir/whisper.cpp/build/bin/whisper-cli" "$build_dir/EasyWhisperUI.app/Contents/MacOS/"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -317,7 +317,19 @@ void MainWindow::processAudioFile(const QString &inputFilePath)
                     ffmpegProcess->deleteLater();
                     processList.removeOne(ffmpegProcess);
                 });
-        ffmpegProcess->start("ffmpeg", ffmpegArgs);
+        #ifdef Q_OS_MACOS
+            ui->console->appendPlainText("Looking for ffmpeg");
+            QProcess findFfmpegProcess;
+            findFfmpegProcess.start("zsh", QStringList() << "-c" << "source /etc/zshrc || true && source ~/.zshrc || true && source /etc/zprofile || true && source ~/.zprofile || true && which ffmpeg");
+            if (findFfmpegProcess.waitForFinished()) {
+                QString ffmpegPath = findFfmpegProcess.readAllStandardOutput().trimmed();
+                ui->console->appendPlainText("ffmpeg found at:" + ffmpegPath);
+                ffmpegProcess->start(ffmpegPath, ffmpegArgs);
+            }
+        #endif
+        #ifndef Q_OS_MACOS
+            ffmpegProcess->start("ffmpeg", ffmpegArgs);
+        #endif
     } else {
         // Already MP3; proceed directly.
         checkAndDownloadModel();


### PR DESCRIPTION
The solution involves executing a shell command that sources the user's shell configuration files (zprofile, zshrc) to load the PATH variable and then checks for the presence of ffmpeg.

While this approach is not ideal and may not cover all edge cases, it provides a reasonable workaround for the current issue.
