### PR TITLE
Update mainwindow.ui - added all supported Whisper languages

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>637</width>
-    <height>548</height>
+    <height>564</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -380,6 +380,96 @@
           </property>
           <item>
            <property name="text">
+            <string>af</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>am</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ar</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>as</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>az</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ba</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>be</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>bg</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>bn</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>bo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>br</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>bs</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ca</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>cs</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>cy</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>da</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>de</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>el</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string>en</string>
            </property>
           </item>
@@ -390,17 +480,97 @@
           </item>
           <item>
            <property name="text">
+            <string>et</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>eu</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>fa</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>fi</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>fo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string>fr</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>de</string>
+            <string>gl</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>zh</string>
+            <string>gu</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ha</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>haw</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>he</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>hi</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>hr</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ht</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>hu</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>hy</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>id</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>is</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>it</string>
            </property>
           </item>
           <item>
@@ -410,12 +580,147 @@
           </item>
           <item>
            <property name="text">
+            <string>jw</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ka</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>kk</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>km</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>kn</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string>ko</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>ru</string>
+            <string>la</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>lb</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ln</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>lo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>lt</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>lv</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mg</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mi</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mk</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ml</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mn</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mr</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ms</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>mt</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>my</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ne</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>nl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>nn</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>no</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>oc</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>pa</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>pl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ps</string>
            </property>
           </item>
           <item>
@@ -425,12 +730,152 @@
           </item>
           <item>
            <property name="text">
-            <string>ar</string>
+            <string>ro</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string/>
+            <string>ru</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sa</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sd</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>si</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sk</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sn</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>so</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sq</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sr</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>su</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sv</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>sw</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ta</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>te</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>tg</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>th</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>tk</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>tl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>tr</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>tt</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>uk</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ur</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>uz</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>vi</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yi</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>yue</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>zh</string>
            </property>
           </item>
          </widget>
@@ -447,7 +892,7 @@
      <x>0</x>
      <y>0</y>
      <width>637</width>
-     <height>19</height>
+     <height>23</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
Hi, 

I have added all the supported, by Whisper, languages to be used for a transcription of audio to text.

For me the usecase was that I wanted to transcribe a Dutch audio file, which was not selectable inside the GUI, so I first added just only 'nl' but then later I wanted also something in other languages. So I thought why not just all the supported languages :-)

Hope you could merge this, I have already compiled it on Windows 11 and it works here without issues.